### PR TITLE
Fixed event metadata types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "libfb",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libfb",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Facebook MQTT library for Node.js",
   "repository": "https://github.com/ChatPlug/libfb-js",
   "main": "dist/index.js",

--- a/src/types/events/parseDeltaEvent.ts
+++ b/src/types/events/parseDeltaEvent.ts
@@ -74,7 +74,7 @@ export function getEventMetadata (delta: any) {
   return {
     id: delta.messageMetadata.messageId,
     threadId: getThreadId(delta),
-    authorId: delta.messageMetadata.actorFbId,
+    authorId: delta.messageMetadata.actorFbId.toString(),
     message: delta.messageMetadata.adminText
   }
 }

--- a/src/types/message/parseDeltaMessage.ts
+++ b/src/types/message/parseDeltaMessage.ts
@@ -15,5 +15,5 @@ export default function parseDeltaMessage (delta: any) {
 
 export function getThreadId (delta: any) {
   const { threadKey } = delta.messageMetadata || delta
-  return threadKey.threadFbId || threadKey.otherUserFbId
+  return (threadKey.threadFbId || threadKey.otherUserFbId).toString()
 }


### PR DESCRIPTION
Basically, author IDs and thread IDs were numbers but should've been strings.